### PR TITLE
Fix/integration key typo and nslog crash

### DIFF
--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -26,7 +26,7 @@
         [self.comScoreClass setAppName: [self appName]];
         SEGLog(@"[CSComScore setAppName: %@]", [self appName]);
         [self.comScoreClass setSecure: [self useHTTPS]];
-        SEGLog(@"[CSComScore setSecure: %@]", [self useHTTPS]);
+        SEGLog(@"[CSComScore setSecure: %@]", [self useHTTPS] ? @YES : @NO);
         if ([self autoUpdate]) {
             if ([self foregroundOnly]) {
                 [self.comScoreClass enableAutoUpdate:[self autoUpdateInterval] foregroundOnly: YES];

--- a/Segment-ComScore/Classes/SEGComScoreIntegrationFactory.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegrationFactory.m
@@ -34,7 +34,7 @@
 
 - (NSString *)key
 {
-    return @"ComScore";
+    return @"comScore";
 }
 
 @end


### PR DESCRIPTION
This addresses two issues:
1) The ComScore integration had nil project settings because the key is case sensitive and there was a mismatch. This meant that the integration is never actually initialized.
2) Inside the initWithSettings method, the integration logs the result of [self useHTTPS] which returns a BOOL. A BOOL passed as an arg to NSLogv causes a EXEC_BAD_ACCESS crash.