### PR TITLE
Update comscore to V6

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - Analytics (3.7.0)
-  - ComScore (5.8.7):
-    - ComScore/Dynamic (= 5.8.7)
-  - ComScore/Dynamic (5.8.7)
+  - ComScore (6.1.0):
+    - ComScore/Dynamic (= 6.1.0)
+  - ComScore/Dynamic (6.1.0)
   - Expecta (1.0.6)
   - OCHamcrest (7.1.2)
-  - OCMockito (5.1.2):
+  - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-ComScore (3.0.0):
+  - Segment-ComScore (3.1.0-beta):
     - Analytics (~> 3.6)
-    - ComScore (~> 5.0)
+    - ComScore (~> 6.0)
   - Specta (1.0.7)
 
 DEPENDENCIES:
@@ -33,13 +33,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
-  ComScore: 4d377376e44c77de1e435a32fdf38d2507d6906c
+  ComScore: 0d2fc96053ddb4d0d07b2222729fa9d484389cab
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
-  OCMockito: 51a534e667194e1ecae88c5def301cc8b0ab3cc7
-  Segment-ComScore: 972ab17e20a945c17ba1f7f18f11488af6b13299
+  OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
+  Segment-ComScore: 8ae19e5fc419df807ada8226c917e48c2a1f77f4
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 58708c888acf3799898d9149cc9266ed0823f288
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Analytics (3.7.0)
-  - ComScore (6.1.0):
-    - ComScore/Dynamic (= 6.1.0)
-  - ComScore/Dynamic (6.1.0)
+  - ComScore (6.0.0):
+    - ComScore/Dynamic (= 6.0.0)
+  - ComScore/Dynamic (6.0.0)
   - Expecta (1.0.6)
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
-  ComScore: 0d2fc96053ddb4d0d07b2222729fa9d484389cab
+  ComScore: 756ae822566c22ee48802b06a3f81e966fb68dda
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877

--- a/Example/Segment-ComScore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Segment-ComScore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Segment-ComScore/SEGAppDelegate.m
+++ b/Example/Segment-ComScore/SEGAppDelegate.m
@@ -38,7 +38,7 @@
 
     [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
                                properties:@{
-                                   @"content_asset_id" : @"1231312"
+                                   @"asset_id" : @"1231312"
                                }
                                   options:@{
                                             @"integrations": @{

--- a/Example/Segment-ComScore/SEGAppDelegate.m
+++ b/Example/Segment-ComScore/SEGAppDelegate.m
@@ -37,7 +37,9 @@
                                             }];
 
     [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
-                               properties:nil
+                               properties:@{
+                                   @"content_asset_id" : @"1231312"
+                               }
                                   options:@{
                                             @"integrations": @{
                                                     @"com-score": @{
@@ -45,6 +47,24 @@
                                                             }
                                                     }
                                             }];
+    
+    [[SEGAnalytics sharedAnalytics] track:@"Video Ad Started"
+                            properties:@{
+                                @"asset_id" : @"1231312",
+                                @"pod_id" : @"43434234534",
+                                @"type" : @"mid-roll",
+                                @"total_length" : @110,
+                                @"position" : @43,
+                                @"publisher" : @"Adult Swim",
+                                @"title" : @"Rick and Morty Ad"
+                            }
+                           options:@{
+                                     @"integrations": @{
+                                             @"com-score": @{
+                                                     @"c4":@"testing-v2019"
+                                                     }
+                                             }
+                                     }];
     
     [[SEGAnalytics sharedAnalytics] flush];
 

--- a/Example/Tests/Tests-Prefix.pch
+++ b/Example/Tests/Tests-Prefix.pch
@@ -5,7 +5,7 @@
   #import <Specta/Specta.h>
   #import <Expecta/Expecta.h>
   #import <OCMockito/OCMockito.h>
-    #import <OCHamcrest/OCHamcrest.h>
+  #import <OCHamcrest/OCHamcrest.h>
   #import <Analytics/SEGAnalytics.h>
   #import <Segment-ComScore/SEGComScoreIntegrationFactory.h>
   #import <Segment-ComScore/SEGComScoreIntegration.h>

--- a/Example/Tests/Tests-Prefix.pch
+++ b/Example/Tests/Tests-Prefix.pch
@@ -5,6 +5,7 @@
   #import <Specta/Specta.h>
   #import <Expecta/Expecta.h>
   #import <OCMockito/OCMockito.h>
+    #import <OCHamcrest/OCHamcrest.h>
   #import <Analytics/SEGAnalytics.h>
   #import <Segment-ComScore/SEGComScoreIntegrationFactory.h>
   #import <Segment-ComScore/SEGComScoreIntegration.h>

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -60,18 +60,13 @@ describe(@"SEGComScoreIntegration", ^{
     beforeEach(^{
         scorAnalyticsClassMock = mockClass([SCORAnalytics class]);
         mockStreamingAnalytics = mock([SCORStreamingAnalytics class]);
-//        mockPlaybackSession = mock([SCORStreamingPlaybackSession class]);
-//        mockAsset = mock([SCORStreamingAsset class]);
-
         SEGMockStreamingAnalyticsFactory *mockStreamAnalyticsFactory = [[SEGMockStreamingAnalyticsFactory alloc] init];
         mockStreamAnalyticsFactory.streamingAnalytics = mockStreamingAnalytics;
 
         [given(mockStreamingAnalytics.configuration) willReturn:mockConfiguration];
-//        [given([mockPlaybackSession asset]) willReturn:mockAsset];
 
         integration = [[SEGComScoreIntegration alloc] initWithSettings:@{
             @"c2" : @"23243060",
-//            @"publisherSecret" : @"7e529e62366db3423ef3728ca910b8b8"
         } andComScore:scorAnalyticsClassMock andStreamingAnalyticsFactory:mockStreamAnalyticsFactory];
 
     });
@@ -796,7 +791,6 @@ describe(@"After Video Playback Started", ^{
 
         });
     
-        //Stopped here. 
         it(@"videoContentPlaying with adType", ^{
 
 
@@ -1033,48 +1027,8 @@ describe(@"After Video Playback Started", ^{
             assertThat(argumentId, is(advertisingMetaData));
 
         });
-
-//        it(@"videoAdStarted with playPosition and ns_st_ci value", ^{
-//
-//            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started"
-//                properties:@{
-//                    @"asset_id" : @"1231312",
-//                    @"pod_id" : @"43434234534",
-//                    @"type" : @"mid-roll",
-//                    @"total_length" : @110,
-//                    @"position" : @43,
-//                    @"publisher" : @"Adult Swim",
-//                    @"title" : @"Rick and Morty Ad"
-//                }
-//                context:@{}
-//                integrations:@{}];
-//
-//            [integration track:payload];
-//
-//            [verify(mockStreamingAnalytics) startFromPosition:43];
-//            [verify(mockStreamingAnalytics) notifyPlay];
-//
-//        });
-//
-//        it(@"videoAdStarted fallsback to method without position and default ns_st_ci value", ^{
-//            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
-//                @"asset_id" : @"1231312",
-//                @"pod_id" : @"43434234534",
-//                @"total_length" : @110,
-//                @"title" : @"Rick and Morty Ad"
-//            } context:@{}
-//                integrations:@{}];
-//
-//            [integration track:payload];
-//
-//            [verify(mockStreamingAnalytics) notifyPlay];
-//
-//        });
-
+    
         it(@"videoAdStarted fallsback to @'1' without correct type value", ^{
-        //TODO move to unti test for builder
-
-
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
                 @"asset_id" : @"1231312",
                 @"pod_id" : @"43434234534",

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -806,6 +806,7 @@ describe(@"After Video Playback Started", ^{
                    @"title" : @"Big Trouble in Little Sanchez",
                    @"season" : @"2",
                    @"episode" : @"7",
+                   @"type": @"pre-roll",
                    @"genre" : @"cartoon",
                    @"program" : @"Rick and Morty",
                    @"total_length" : @400,
@@ -818,9 +819,40 @@ describe(@"After Video Playback Started", ^{
                                                                             @"tvAirdate" : @"2017-05-22"
                                                                         }
                                                                     }];
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                [builder setCustomLabels:@{ @"ns_st_ci" : @"3543",
+                                            @"ns_st_ep" : @"Big Trouble in Little Sanchez",
+                                            @"ns_st_sn" : @"2",
+                                            @"ns_st_en" : @"7",
+                                            @"ns_st_ge" : @"cartoon",
+                                            @"ns_st_pr" : @"Rick and Morty",
+                                            @"ns_st_cl" : @"400000",
+                                            @"ns_st_ce" : @"true",
+                                            @"ns_st_pu" : @"Turner Broadcasting Network",
+                                            @"ns_st_pn" : @"65462",
+                                            @"ns_st_st" : @"Cartoon Network",
+                                            @"c3" : @"*null",
+                                            @"c4" : @"*null",
+                                            @"c6" : @"*null",
+                                            @"ns_st_tdt" : @"2017-05-22",
+                                            @"ns_st_ddt" : @"*null",
+                                            @"ns_st_ct" : @"vc00"}];
+            }];
 
-               [integration track:payload];
-               [verify(mockStreamingAnalytics) notifyPlay];
+            SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+                [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
+                [builder setRelatedContentMetadata: contentMetaData];
+            }];
+
+            [integration track:payload];
+            [verify(mockStreamingAnalytics) notifyPlay];
+            
+            [mockStreamingAnalytics setMetadata:advertisingMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(advertisingMetaData));
 
            });
 
@@ -843,9 +875,36 @@ describe(@"After Video Playback Started", ^{
 
             } context:@{}
                 integrations:@{}];
+            
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                [builder setCustomLabels:@{ @"ns_st_ci" : @"3543",
+                                            @"ns_st_ep" : @"Big Trouble in Little Sanchez",
+                                            @"ns_st_sn" : @"2",
+                                            @"ns_st_en" : @"7",
+                                            @"ns_st_ge" : @"cartoon",
+                                            @"ns_st_pr" : @"Rick and Morty",
+                                            @"ns_st_cl" : @"400000",
+                                            @"ns_st_ce" : @"true",
+                                            @"ns_st_pu" : @"Turner Broadcasting Network",
+                                            @"ns_st_pn" : @"65462",
+                                            @"ns_st_st" : @"Cartoon Network",
+                                            @"c3" : @"*null",
+                                            @"c4" : @"*null",
+                                            @"c6" : @"*null",
+                                            @"ns_st_tdt" : @"2017-05-22",
+                                            @"ns_st_ddt" : @"*null",
+                                            @"ns_st_ct" : @"vc00"}];
+            }];
 
             [integration track:payload];
             [verify(mockStreamingAnalytics) notifyPlay];
+            
+            [mockStreamingAnalytics setMetadata:contentMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(contentMetaData));
 
         });
 
@@ -866,12 +925,39 @@ describe(@"After Video Playback Started", ^{
 
             } context:@{}
                 integrations:@{}];
+            
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                [builder setCustomLabels:@{ @"ns_st_ci" : @"3543",
+                                            @"ns_st_ep" : @"Big Trouble in Little Sanchez",
+                                            @"ns_st_sn" : @"2",
+                                            @"ns_st_en" : @"7",
+                                            @"ns_st_ge" : @"cartoon",
+                                            @"ns_st_pr" : @"Rick and Morty",
+                                            @"ns_st_cl" : @"400000",
+                                            @"ns_st_ce" : @"true",
+                                            @"ns_st_pu" : @"Turner Broadcasting Network",
+                                            @"ns_st_pn" : @"65462",
+                                            @"ns_st_st" : @"Cartoon Network",
+                                            @"c3" : @"*null",
+                                            @"c4" : @"*null",
+                                            @"c6" : @"*null",
+                                            @"ns_st_tdt" : @"2017-05-22",
+                                            @"ns_st_ddt" : @"*null",
+                                            @"ns_st_ct" : @"vc00"}];
+            }];
 
             [integration track:payload];
             [verify(mockStreamingAnalytics) notifyPlay];
+            
+            [mockStreamingAnalytics setMetadata:contentMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(contentMetaData));
         });
 
-        it(@"videoContentCompleted with playPosition", ^{
+        it(@"videoContentCompleted", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Completed" properties:@{
                 @"asset_id" : @"3543",
@@ -893,69 +979,12 @@ describe(@"After Video Playback Started", ^{
             [verify(mockStreamingAnalytics) notifyEnd];
         });
 
-        it(@"videoContentCompleted fallsback to method without position", ^{
-
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Completed" properties:@{
-                @"asset_id" : @"3543",
-                @"pod_id" : @"65462",
-                @"title" : @"Big Trouble in Little Sanchez",
-                @"season" : @"2",
-                @"episode" : @"7",
-                @"genre" : @"cartoon",
-                @"program" : @"Rick and Morty",
-                @"total_length" : @400,
-                @"full_episode" : @"true",
-                @"publisher" : @"Turner Broadcasting Network",
-                @"channel" : @"Cartoon Network"
-            } context:@{}
-                integrations:@{}];
-            
-            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
-            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-                           [builder setCustomLabels:@{  @"ns_st_ci" : @"0" }];
-                           [builder setCustomLabels:@{ @"ns_st_ep" : @"Big Trouble in Little Sanchez" }];
-                           [builder setCustomLabels:@{ @"ns_st_sn" : @"2" }];
-                           [builder setCustomLabels:@{ @"ns_st_en" : @"7" }];
-                           [builder setCustomLabels:@{ @"ns_st_ge" : @"cartoon" }];
-                           [builder setCustomLabels:@{ @"ns_st_pr" : @"Rick and Morty" }];
-                           [builder setCustomLabels:@{  @"ns_st_ct" : @"vc00" }];
-                      }];
-
-            [integration track:payload];
-            [mockStreamingAnalytics setMetadata:contentMetaData];
-            [verify(mockStreamingAnalytics) setMetadata:captor];
-            id argumentId = captor.value;
-            assertThat(argumentId, notNilValue());
-            assertThat(argumentId, is(contentMetaData));
-            [verify(mockStreamingAnalytics) notifyEnd];
-        });
-    
-        it(@"maps content metadata correctly", ^{
-            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-                [builder setCustomLabels:@{  @"ns_st_ci" : @"0" }];
-                [builder setCustomLabels:@{ @"ns_st_ep" : @"Big Trouble in Little Sanchez" }];
-                [builder setCustomLabels:@{ @"ns_st_sn" : @"2" }];
-                [builder setCustomLabels:@{ @"ns_st_en" : @"7" }];
-                [builder setCustomLabels:@{ @"ns_st_ge" : @"cartoon" }];
-                [builder setCustomLabels:@{ @"ns_st_pr" : @"Rick and Morty" }];
-                [builder setCustomLabels:@{  @"ns_st_ct" : @"vc00" }];
-           }];
-
-            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
-            [mockStreamingAnalytics setMetadata:contentMetaData];
-            [verify(mockStreamingAnalytics) setMetadata:captor];
-
-            id argumentId = captor.value;
-            assertThat(argumentId, notNilValue());
-            assertThat(argumentId, is(contentMetaData));
-        });
-
         //#pragma Ad Events
 
-        it(@"videoAdStarted with playPosition and default ns_st_ci value", ^{
-
+        it(@"videoAdStarted with playPosition and ns_st_ci value", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
+                @"content_asset_id": @"3543",
                 @"asset_id" : @"1231312",
                 @"pod_id" : @"43434234534",
                 @"type" : @"mid-roll",
@@ -967,57 +996,70 @@ describe(@"After Video Playback Started", ^{
                 integrations:@{}];
 
             [integration track:payload];
+            
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                         [builder setCustomLabels:@{ @"ns_st_ci" : @"3543",
+                                                     @"ns_st_cl" : @"110000",
+                                                     @"ns_st_pu" : @"Adult Swim",
+                                                     @"c3" : @"*null",
+                                                     @"c4" : @"*null",
+                                                     @"c6" : @"*null",
+                                                     @"ns_st_ddt" : @"*null",
+                                                     @"ns_st_ct" : @"vc00"}];
+                     }];
+            
+            SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+                [builder setMediaType: SCORStreamingAdvertisementTypeBrandedOnDemandMidRoll];
+                [builder setCustomLabels: @{
+                    @"ns_st_ci": @"3543",
+                    @"ns_st_ami": @"1231312",
+                    @"ns_st_ad": @"0",
+                    @"ns_st_cl": @"110000",
+                    @"ns_st_amt": @"Rick and Morty Ad",
+                    @"ns_st_pu": @"Adult Swim",
+                    @"ns_st_ct": @"va00"
+                }];
+                [builder setRelatedContentMetadata: contentMetaData];
+            }];
 
             [verify(mockStreamingAnalytics) startFromPosition:43];
             [verify(mockStreamingAnalytics) notifyPlay];
+            
+            [mockStreamingAnalytics setMetadata:advertisingMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(advertisingMetaData));
 
         });
 
-        it(@"videoAdStarted with playPosition and ns_st_ci value", ^{
-//            [given([mockAsset label:@"ns_st_ci"]) willReturn:@"1234"];
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started"
-                properties:@{
-                    @"asset_id" : @"1231312",
-                    @"pod_id" : @"43434234534",
-                    @"type" : @"mid-roll",
-                    @"total_length" : @110,
-                    @"position" : @43,
-                    @"publisher" : @"Adult Swim",
-                    @"title" : @"Rick and Morty Ad"
-                }
-                context:@{}
-                integrations:@{}];
-
-            [integration track:payload];
-
-            [verify(mockStreamingAnalytics) startFromPosition:43];
-            [verify(mockStreamingAnalytics) notifyPlay];
-
-        });
-
-        it(@"videoAdStarted fallsback to method without position and default ns_st_ci value", ^{
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
-                @"asset_id" : @"1231312",
-                @"pod_id" : @"43434234534",
-                @"total_length" : @110,
-                @"title" : @"Rick and Morty Ad"
-            } context:@{}
-                integrations:@{}];
-
-            [integration track:payload];
-
-            [verify(mockStreamingAnalytics) notifyPlay];
-
-        });
-
-//        it(@"videoAdStarted fallsback to @'1' without correct type value", ^{
-//        //TODO move to unti test for builder
+//        it(@"videoAdStarted with playPosition and ns_st_ci value", ^{
 //
+//            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started"
+//                properties:@{
+//                    @"asset_id" : @"1231312",
+//                    @"pod_id" : @"43434234534",
+//                    @"type" : @"mid-roll",
+//                    @"total_length" : @110,
+//                    @"position" : @43,
+//                    @"publisher" : @"Adult Swim",
+//                    @"title" : @"Rick and Morty Ad"
+//                }
+//                context:@{}
+//                integrations:@{}];
 //
+//            [integration track:payload];
+//
+//            [verify(mockStreamingAnalytics) startFromPosition:43];
+//            [verify(mockStreamingAnalytics) notifyPlay];
+//
+//        });
+//
+//        it(@"videoAdStarted fallsback to method without position and default ns_st_ci value", ^{
 //            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
 //                @"asset_id" : @"1231312",
 //                @"pod_id" : @"43434234534",
-//                @"type" : @"not an ad type",
 //                @"total_length" : @110,
 //                @"title" : @"Rick and Morty Ad"
 //            } context:@{}
@@ -1025,59 +1067,128 @@ describe(@"After Video Playback Started", ^{
 //
 //            [integration track:payload];
 //
-//            NSDictionary *expected = @{
-//                @"ns_st_ami" : @"1231312",
-//                @"ns_st_ad" : @"1",
-//                @"ns_st_cl" : @"110000",
-//                @"ns_st_amt" : @"Rick and Morty Ad",
-//                @"ns_st_pu" : @"*null",
-//                @"c3" : @"*null",
-//                @"c4" : @"*null",
-//                @"c6" : @"*null",
-//                @"ns_st_ct" : @"va00",
-//                @"ns_st_ci" : @"0"
-//
-//            };
-//
-//            [verify(mockPlaybackSession) setAssetWithLabels:expected];
 //            [verify(mockStreamingAnalytics) notifyPlay];
+//
 //        });
-//
-//        it(@"videoAdStarted maps adClassificationType value passed in integrations object", ^{
-//
-//
-//            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
-//                @"asset_id" : @"1231312",
-//                @"pod_id" : @"43434234534",
-//                @"type" : @"mid-roll",
-//                @"total_length" : @110,
-//                @"position" : @110,
-//                @"title" : @"Rick and Morty Ad"
-//
-//            } context:@{}
-//                                                                 integrations:@{ @"com-score" : @{
-//                                                                     @"adClassificationType" : @"va12"
-//                                                                 } }];
-//
-//            [integration track:payload];
-//
-//            NSDictionary *expected = @{
-//                @"ns_st_ami" : @"1231312",
-//                @"ns_st_ad" : @"mid-roll",
-//                @"ns_st_cl" : @"110000",
-//                @"ns_st_amt" : @"Rick and Morty Ad",
-//                @"ns_st_pu" : @"*null",
-//                @"c3" : @"*null",
-//                @"c4" : @"*null",
-//                @"c6" : @"*null",
-//                @"ns_st_ct" : @"va12",
-//                @"ns_st_ci" : @"0"
-//            };
-//
-//            [verify(mockPlaybackSession) setAssetWithLabels:expected];
-//            [verify(mockStreamingAnalytics) notifyPlayWithPosition:110];
-//        });
-//
+
+        it(@"videoAdStarted fallsback to @'1' without correct type value", ^{
+        //TODO move to unti test for builder
+
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
+                @"asset_id" : @"1231312",
+                @"pod_id" : @"43434234534",
+                @"type" : @"not an ad type",
+                @"total_length" : @110,
+                @"title" : @"Rick and Morty Ad"
+            } context:@{}
+                integrations:@{}];
+
+            [integration track:payload];
+
+            NSDictionary *expected = @{
+                @"ns_st_ami" : @"1231312",
+                @"ns_st_ad" : @"1",
+                @"ns_st_cl" : @"110000",
+                @"ns_st_amt" : @"Rick and Morty Ad",
+                @"ns_st_pu" : @"*null",
+                @"c3" : @"*null",
+                @"c4" : @"*null",
+                @"c6" : @"*null",
+                @"ns_st_ct" : @"va00",
+                @"ns_st_ci" : @"0"
+
+            };
+            
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                         [builder setCustomLabels:@{ @"ns_st_ci" : @"0",
+                                                     @"ns_st_cl" : @"110000",
+                                                     @"ns_st_pu" : @"*null",
+                                                     @"c3" : @"*null",
+                                                     @"c4" : @"*null",
+                                                     @"c6" : @"*null",
+                                                     @"ns_st_ct" : @"va00"}];
+                     }];
+            
+            SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+                [builder setMediaType: SCORStreamingAdvertisementTypeBrandedOnDemandMidRoll];
+                [builder setCustomLabels: @{
+                    @"ns_st_ci": @"3543",
+                    @"ns_st_ami": @"1231312",
+                    @"ns_st_ad": @"1",
+                    @"ns_st_cl": @"110000",
+                    @"ns_st_amt": @"Rick and Morty Ad",
+                    @"ns_st_pu": @"*null",
+                    @"ns_st_ct": @"va00"
+                }];
+                [builder setRelatedContentMetadata: contentMetaData];
+            }];
+
+            [verify(mockStreamingAnalytics) notifyPlay];
+            
+            [mockStreamingAnalytics setMetadata:advertisingMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(advertisingMetaData));
+        });
+
+        it(@"videoAdStarted maps adClassificationType value passed in integrations object", ^{
+
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started" properties:@{
+                @"asset_id" : @"1231312",
+                @"pod_id" : @"43434234534",
+                @"type" : @"mid-roll",
+                @"total_length" : @110,
+                @"position" : @110,
+                @"title" : @"Rick and Morty Ad"
+
+            } context:@{}
+                                                                 integrations:@{ @"com-score" : @{
+                                                                     @"adClassificationType" : @"va12"
+                                                                 } }];
+
+            [integration track:payload];
+            
+            
+            HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
+            SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+                         [builder setCustomLabels:@{ @"ns_st_ci" : @"0",
+                                                     @"ns_st_cl" : @"110000",
+                                                     @"ns_st_pu" : @"*null",
+                                                     @"c3" : @"*null",
+                                                     @"c4" : @"*null",
+                                                     @"c6" : @"*null",
+                                                    }];
+                     }];
+            
+            SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+                [builder setMediaType: SCORStreamingAdvertisementTypeBrandedOnDemandMidRoll];
+                [builder setCustomLabels: @{
+                    @"ns_st_ci": @"3543",
+                    @"ns_st_ami": @"1231312",
+                    @"ns_st_ad": @"1",
+                    @"ns_st_cl": @"110000",
+                    @"ns_st_amt": @"Rick and Morty Ad",
+                    @"ns_st_pu": @"*null",
+                    @"ns_st_ct": @"va12"
+                }];
+                [builder setRelatedContentMetadata: contentMetaData];
+            }];
+
+            [verify(mockStreamingAnalytics) notifyPlay];
+            [verify(mockStreamingAnalytics) startFromPosition:110];
+            
+            
+            [mockStreamingAnalytics setMetadata:advertisingMetaData];
+            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            id argumentId = captor.value;
+            assertThat(argumentId, notNilValue());
+            assertThat(argumentId, is(advertisingMetaData));
+        });
+
         it(@"videoAdPlaying with playPosition", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Playing" properties:@{
@@ -1112,25 +1223,7 @@ describe(@"After Video Playback Started", ^{
             [verify(mockStreamingAnalytics) notifyPlay];
         });
 
-        it(@"videoAdCompleted with playPosition", ^{
-
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Completed" properties:@{
-                @"asset_id" : @"1231312",
-                @"pod_id" : @"43434234534",
-                @"type" : @"mid-roll",
-                @"total_length" : @110,
-                @"position" : @110,
-                @"title" : @"Rick and Morty Ad"
-
-            } context:@{}
-                integrations:@{}];
-
-            [integration track:payload];
-            [verify(mockStreamingAnalytics) startFromPosition:110];
-            [verify(mockStreamingAnalytics) notifyEnd];
-        });
-
-        it(@"videoAdCompleted fallsback to method without position", ^{
+        it(@"videoAdCompleted", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Completed" properties:@{
                 @"asset_id" : @"1231312",

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -843,7 +843,7 @@ describe(@"After Video Playback Started", ^{
             [verify(mockStreamingAnalytics) notifyPlay];
             
             [mockStreamingAnalytics setMetadata:advertisingMetaData];
-            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            [verifyCount(mockStreamingAnalytics, times(1)) setMetadata:captor];
             id argumentId = captor.value;
             assertThat(argumentId, notNilValue());
             assertThat(argumentId, is(advertisingMetaData));
@@ -895,7 +895,7 @@ describe(@"After Video Playback Started", ^{
             [verify(mockStreamingAnalytics) notifyPlay];
             
             [mockStreamingAnalytics setMetadata:contentMetaData];
-            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            [verifyCount(mockStreamingAnalytics, times(1)) setMetadata:captor];
             id argumentId = captor.value;
             assertThat(argumentId, notNilValue());
             assertThat(argumentId, is(contentMetaData));
@@ -945,7 +945,7 @@ describe(@"After Video Playback Started", ^{
             [verify(mockStreamingAnalytics) notifyPlay];
             
             [mockStreamingAnalytics setMetadata:contentMetaData];
-            [verifyCount(mockStreamingAnalytics, times(2)) setMetadata:captor];
+            [verifyCount(mockStreamingAnalytics, times(1)) setMetadata:captor];
             id argumentId = captor.value;
             assertThat(argumentId, notNilValue());
             assertThat(argumentId, is(contentMetaData));
@@ -1039,20 +1039,6 @@ describe(@"After Video Playback Started", ^{
                 integrations:@{}];
 
             [integration track:payload];
-
-            NSDictionary *expected = @{
-                @"ns_st_ami" : @"1231312",
-                @"ns_st_ad" : @"1",
-                @"ns_st_cl" : @"110000",
-                @"ns_st_amt" : @"Rick and Morty Ad",
-                @"ns_st_pu" : @"*null",
-                @"c3" : @"*null",
-                @"c4" : @"*null",
-                @"c6" : @"*null",
-                @"ns_st_ct" : @"va00",
-                @"ns_st_ci" : @"0"
-
-            };
             
             HCArgumentCaptor *captor = [[HCArgumentCaptor alloc] init];
             SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {

--- a/Segment-ComScore.podspec
+++ b/Segment-ComScore.podspec
@@ -22,5 +22,5 @@ s.requires_arc = true
 s.source_files = 'Segment-ComScore/Classes/**/*'
 
 s.dependency 'Analytics', '~> 3.6'
-s.dependency 'ComScore', '~> 5.0'
+s.dependency 'ComScore', '~> 6.0'
 end

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -10,7 +10,6 @@
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <ComScore/SCORStreamingAnalytics.h>
 
-
 @implementation SEGRealStreamingAnalyticsFactory
 
 - (SCORStreamingAnalytics *)create;
@@ -23,7 +22,6 @@
 @interface SCORStreamingConfiguration(Private)
 @property(copy) NSDictionary *labels;
 @end
-
 
 @implementation SEGComScoreIntegration
 
@@ -53,7 +51,7 @@
 
         SCORAnalytics.configuration.liveTransmissionMode = SCORLiveTransmissionModeLan;
 
-        SCORAnalytics.configuration.applicationName = settings[@"appName:"];
+        SCORAnalytics.configuration.applicationName = settings[@"appName"];
 
         SCORPartnerConfiguration *partnerConfig = [SCORPartnerConfiguration partnerConfigurationWithBuilderBlock:^(SCORPartnerConfigurationBuilder *builder) {
             builder.partnerId = @"23243060";
@@ -424,7 +422,7 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
     SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:contentMap];
 
     NSDictionary *adMap = returnMappedAdProperties(properties, integrations);
-    SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+    SCORStreamingAdvertisementMetadata *advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
         [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
         [builder setRelatedContentMetadata: contentMetadata];
     }];
@@ -496,7 +494,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     } else if ([adType isEqualToString:@"post-roll"]) {
         setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPostRoll;
     } else {
-        setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPreRoll;
+        setMediaType = SCORStreamingAdvertisementTypeOther;
     }
 
     SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -279,7 +279,7 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
 
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    // [self.streamAnalytics.configuration addLabels:map]; TBD if needed
+    [self.streamAnalytics.configuration addLabels:map];
     [self.streamAnalytics setMetadata:playbackMetaData];
 
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] createPlaybackSessionWithLabels: %@]", map);
@@ -404,8 +404,9 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
     NSDictionary *map = returnMappedContentProperties(properties, integrations);
     SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
 
-    // [self.streamAnalytics.configuration addLabels:map];//TBD if needed
+    [self.streamAnalytics.configuration addLabels:map];
     [self.streamAnalytics setMetadata:contentMetadata];
+
     SEGLog(@"[SCORStreamingAnalytics setMetadata:%@", contentMetadata);
 
     [self movePosition:properties];
@@ -417,9 +418,6 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
 {
     NSDictionary *contentMap = returnMappedContentProperties(properties, integrations);
     SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:contentMap];
-//    SCORStreamingContentMetadata *contentMetadata = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//          [builder setCustomLabels:map];
-//    }];
 
     NSDictionary *adMap = returnMappedAdProperties(properties, integrations);
     SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
@@ -484,10 +482,22 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
     [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
 
-    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
+    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:mapWithContentId];
+    NSString *adType = [properties valueForKey:@"type"];
+    __block NSInteger setMediaType;
+    if ([adType isEqualToString:@"pre-roll"]) {
+        setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPreRoll;
+    } else if ([adType isEqualToString:@"midroll"]) {
+        setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandMidRoll;
+    } else if ([adType isEqualToString:@"post-roll"]) {
+        setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPostRoll;
+    } else {
+        setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPreRoll;
+    }
 
     SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
-        [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
+        [builder setMediaType: setMediaType];
+        [builder setCustomLabels: mapWithContentId];
         [builder setRelatedContentMetadata: contentMetadata];
     }];
 

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -20,6 +20,10 @@
 
 @end
 
+@interface SCORStreamingConfiguration(Private)
+@property(copy) NSDictionary *labels;
+@end
+
 
 @implementation SEGComScoreIntegration
 

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -36,7 +36,7 @@
             builder.publisherId = settings[@"c2"];
             builder.secureTransmissionEnabled = [(NSNumber *)[self.settings objectForKey:@"useHTTPS"] boolValue];
         }];
-        
+
         NSInteger usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeDisabled;
         if ([(NSNumber *)[self.settings objectForKey:@"autoUpdate"] boolValue] && [(NSNumber *)[self.settings objectForKey:@"foregroundOnly"] boolValue]) {
             usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundOnly;
@@ -44,11 +44,11 @@
             usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundAndBackground;
         }
         SCORAnalytics.configuration.usagePropertiesAutoUpdateMode = usagePropertyAutoUpdateMode;
-        
+
         SCORAnalytics.configuration.usagePropertiesAutoUpdateInterval = [settings[@"autoUpdateInterval"] intValue];
-        
+
         SCORAnalytics.configuration.liveTransmissionMode = SCORLiveTransmissionModeLan;
-        
+
         SCORAnalytics.configuration.applicationName = settings[@"appName:"];
 
         SCORPartnerConfiguration *partnerConfig = [SCORPartnerConfiguration partnerConfigurationWithBuilderBlock:^(SCORPartnerConfigurationBuilder *builder) {
@@ -57,7 +57,7 @@
 
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:partnerConfig];
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:config];
-        
+
         [[self.scorAnalyticsClass configuration] enableImplementationValidationMode];
 
         [self.scorAnalyticsClass start];
@@ -277,16 +277,9 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
 
     [self.streamAnalytics createPlaybackSession];
 
-    // The label ns_st_ci must be set through a setAsset call
-    
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//        [builder setCustomLabels:map];
-//    }];
-    
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    
-    [self.streamAnalytics.configuration addLabels:map];
+    // [self.streamAnalytics.configuration addLabels:map]; TBD if needed
     [self.streamAnalytics setMetadata:playbackMetaData];
 
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] createPlaybackSessionWithLabels: %@]", map);
@@ -298,10 +291,7 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//           [builder setCustomLabels:map];
-//    }];
-    [self.streamAnalytics.configuration addLabels:map];
+    // [self.streamAnalytics.configuration addLabels:map]; TBD if needed
     [self.streamAnalytics setMetadata:playbackMetaData];
 
     [self.streamAnalytics notifyPause];
@@ -313,11 +303,8 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//             [builder setCustomLabels:map];
-//      }];
     [self.streamAnalytics setMetadata:playbackMetaData];
-    
+
     [self.streamAnalytics notifyPause];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPause]");
 }
@@ -327,11 +314,9 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//               [builder setCustomLabels:map];
-//        }];
     [self.streamAnalytics setMetadata:playbackMetaData];
 
+    [self movePosition:properties];
     [self.streamAnalytics notifyBufferStart];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStart]");
 }
@@ -341,11 +326,9 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//           [builder setCustomLabels:map];
-//    }];
     [self.streamAnalytics setMetadata:playbackMetaData];
 
+    [self movePosition:properties];
     [self.streamAnalytics notifyBufferStop];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStop]");
 }
@@ -355,11 +338,8 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//           [builder setCustomLabels:map];
-//    }];
     [self.streamAnalytics setMetadata:playbackMetaData];
-    
+
     [self seekPosition:properties];
     [self.streamAnalytics notifySeekStart];
     SEGLog(@"[[SCORStreamAnalytics streamAnalytics] notifySeekStart]");
@@ -370,11 +350,8 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//          [builder setCustomLabels:map];
-//    }];
     [self.streamAnalytics setMetadata:playbackMetaData];
-   
+
     [self seekPosition:properties];
     [self.streamAnalytics notifyPlay];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
@@ -385,12 +362,10 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
     SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
-//
-//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//      [builder setCustomLabels:map];
-//    }];
+
     [self.streamAnalytics setMetadata:playbackMetaData];
 
+    [self movePosition:properties];
     [self.streamAnalytics notifyPlay];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
@@ -429,26 +404,24 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
     NSDictionary *map = returnMappedContentProperties(properties, integrations);
     SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
 
-//    SCORStreamingContentMetadata *contentMetadata = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
-//          [builder setCustomLabels:map];
-//    }];
-    [self.streamAnalytics.configuration addLabels:map];
+    // [self.streamAnalytics.configuration addLabels:map];//TBD if needed
     [self.streamAnalytics setMetadata:contentMetadata];
-
     SEGLog(@"[SCORStreamingAnalytics setMetadata:%@", contentMetadata);
 
+    [self movePosition:properties];
     [self.streamAnalytics notifyPlay];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay;");
 }
 
 - (void)videoContentPlaying:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
-    NSDictionary *map = returnMappedContentProperties(properties, integrations);
-    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
+    NSDictionary *contentMap = returnMappedContentProperties(properties, integrations);
+    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:contentMap];
 //    SCORStreamingContentMetadata *contentMetadata = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
 //          [builder setCustomLabels:map];
 //    }];
 
+    NSDictionary *adMap = returnMappedAdProperties(properties, integrations);
     SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
         [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
         [builder setRelatedContentMetadata: contentMetadata];
@@ -457,12 +430,12 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
     // we need to call setAsset with the content metadata.  If ns_st_ad is not present, that means the last
     // observed event was related to content, in which case a setAsset call should not be made (because asset
     // did not change).
-    if ([map objectForKey:@"ns_st_ad"]) {
-        [self.streamAnalytics setMetadata:contentMetadata];
-    } else {
+    if ([adMap objectForKey:@"ns_st_ad"]) {
         [self.streamAnalytics setMetadata:advertisingMetaData];
+    } else {
+        [self.streamAnalytics setMetadata:contentMetadata];
     }
-    
+
     [self movePosition:properties];
 
     [self.streamAnalytics notifyPlay];
@@ -507,17 +480,17 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     // Started (if this is a pre-roll).
     NSDictionary *labels = self.streamAnalytics.configuration.labels;
     NSString *contentId = [labels objectForKey:@"ns_st_ci"] ?: @"0";
-    
+
     NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
     [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
-    
+
     SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
-                                                     
+
     SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
         [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
         [builder setRelatedContentMetadata: contentMetadata];
     }];
-    
+
     [self.streamAnalytics setMetadata:advertisingMetaData];
 
     [self movePosition: properties];
@@ -534,6 +507,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
 
 - (void)videoAdCompleted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
+    [self movePosition:properties];
     [self.streamAnalytics notifyEnd];
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEnd]");
 }
@@ -556,20 +530,20 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
         if (self.streamAnalytics != NULL) {
             [self.streamAnalytics startFromPosition:seekPosition];
         }
-        
+
     }
 }
 
 - (SCORStreamingContentMetadata *)instantiateContentMetaData:(NSDictionary *)properties {
-    
+
     SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
         [builder setCustomLabels:properties];
-        
+
         if (properties[@"ns_st_ge"]) {
             [builder setGenreName:properties[@"genre"]];
         }
     }];
-  
+
     return contentMetaData;
 }
 

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -59,9 +59,6 @@
 
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:partnerConfig];
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:config];
-
-        [[self.scorAnalyticsClass configuration] enableImplementationValidationMode];
-
         [self.scorAnalyticsClass start];
     }
     return self;
@@ -485,7 +482,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     __block NSInteger setMediaType;
     if ([adType isEqualToString:@"pre-roll"]) {
         setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPreRoll;
-    } else if ([adType isEqualToString:@"midroll"]) {
+    } else if ([adType isEqualToString:@"mid-roll"]) {
         setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandMidRoll;
     } else if ([adType isEqualToString:@"post-roll"]) {
         setMediaType = SCORStreamingAdvertisementTypeBrandedOnDemandPostRoll;
@@ -493,7 +490,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
         setMediaType = SCORStreamingAdvertisementTypeOther;
     }
 
-    SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+    SCORStreamingAdvertisementMetadata *advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
         [builder setMediaType: setMediaType];
         [builder setCustomLabels: mapWithContentId];
         [builder setRelatedContentMetadata: contentMetadata];

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -34,20 +34,22 @@
         SCORPublisherConfiguration *config = [SCORPublisherConfiguration publisherConfigurationWithBuilderBlock:^(SCORPublisherConfigurationBuilder *builder) {
             // publisherId is also known as c2 value
             builder.publisherId = settings[@"c2"];
-            builder.publisherSecret = settings[@"publisherSecret"];
-            builder.applicationName = settings[@"appName:"];
-            builder.usagePropertiesAutoUpdateInterval = [settings[@"autoUpdateInterval"] integerValue];
-            builder.secureTransmission = [(NSNumber *)[self.settings objectForKey:@"useHTTPS"] boolValue];
-            builder.liveTransmissionMode = SCORLiveTransmissionModeLan;
-
-            if ([(NSNumber *)[self.settings objectForKey:@"autoUpdate"] boolValue] && [(NSNumber *)[self.settings objectForKey:@"foregroundOnly"] boolValue]) {
-                builder.usagePropertiesAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundOnly;
-            } else if ([(NSNumber *)[self.settings objectForKey:@"autoUpdate"] boolValue]) {
-                builder.usagePropertiesAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundAndBackground;
-            } else {
-                builder.usagePropertiesAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeDisabled;
-            }
+            builder.secureTransmissionEnabled = [(NSNumber *)[self.settings objectForKey:@"useHTTPS"] boolValue];
         }];
+        
+        NSInteger usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeDisabled;
+        if ([(NSNumber *)[self.settings objectForKey:@"autoUpdate"] boolValue] && [(NSNumber *)[self.settings objectForKey:@"foregroundOnly"] boolValue]) {
+            usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundOnly;
+        } else if ([(NSNumber *)[self.settings objectForKey:@"autoUpdate"] boolValue]) {
+            usagePropertyAutoUpdateMode = SCORUsagePropertiesAutoUpdateModeForegroundAndBackground;
+        }
+        SCORAnalytics.configuration.usagePropertiesAutoUpdateMode = usagePropertyAutoUpdateMode;
+        
+        SCORAnalytics.configuration.usagePropertiesAutoUpdateInterval = [settings[@"autoUpdateInterval"] intValue];
+        
+        SCORAnalytics.configuration.liveTransmissionMode = SCORLiveTransmissionModeLan;
+        
+        SCORAnalytics.configuration.applicationName = settings[@"appName:"];
 
         SCORPartnerConfiguration *partnerConfig = [SCORPartnerConfiguration partnerConfigurationWithBuilderBlock:^(SCORPartnerConfigurationBuilder *builder) {
             builder.partnerId = @"23243060";
@@ -55,6 +57,8 @@
 
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:partnerConfig];
         [[self.scorAnalyticsClass configuration] addClientWithConfiguration:config];
+        
+        [[self.scorAnalyticsClass configuration] enableImplementationValidationMode];
 
         [self.scorAnalyticsClass start];
     }
@@ -268,14 +272,22 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
 
     NSDictionary *map = @{
         @"ns_st_mp" : properties[@"video_player"] ?: @"*null",
+        @"ns_st_ci" : properties[@"content_asset_id"] ?: @"0"
     };
 
-    [self.streamAnalytics createPlaybackSessionWithLabels:map];
+    [self.streamAnalytics createPlaybackSession];
 
     // The label ns_st_ci must be set through a setAsset call
-    [[self.streamAnalytics playbackSession] setAssetWithLabels:@{
-        @"ns_st_ci" : properties[@"content_asset_id"] ?: @"0"
-    }];
+    
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//        [builder setCustomLabels:map];
+//    }];
+    
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
+
+    
+    [self.streamAnalytics.configuration addLabels:map];
+    [self.streamAnalytics setMetadata:playbackMetaData];
 
     SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] createPlaybackSessionWithLabels: %@]", map);
 }
@@ -284,108 +296,103 @@ NSDictionary *returnMappedPlaybackProperties(NSDictionary *properties, NSDiction
 - (void)videoPlaybackPaused:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPauseWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPauseWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyPause];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPause]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//           [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics.configuration addLabels:map];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+
+    [self.streamAnalytics notifyPause];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPause]");
 }
 
 - (void)videoPlaybackInterrupted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPauseWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPauseWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyPause];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPause]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//             [builder setCustomLabels:map];
+//      }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+    
+    [self.streamAnalytics notifyPause];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPause]");
 }
 
 - (void)videoPlaybackBufferStarted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyBufferStartWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStartWithPosition: %ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyBufferStart];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStart]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//               [builder setCustomLabels:map];
+//        }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+
+    [self.streamAnalytics notifyBufferStart];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStart]");
 }
 
 - (void)videoPlaybackBufferCompleted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyBufferStopWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStopWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyBufferStop];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStop]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//           [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+
+    [self.streamAnalytics notifyBufferStop];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyBufferStop]");
 }
-
 
 - (void)videoPlaybackSeekStarted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"seek_position"] longValue]) {
-        long seekPosition = [properties[@"seek_position"] longValue];
-        [self.streamAnalytics notifySeekStartWithPosition:seekPosition];
-        SEGLog(@"[[SCORStreamAnalytics streamAnalytics] notifySeekStartWithPosition:%ld]", seekPosition);
-    } else {
-        [self.streamAnalytics notifySeekStart];
-        SEGLog(@"[[SCORStreamAnalytics streamAnalytics] notifySeekStart]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//           [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+    
+    [self seekPosition:properties];
+    [self.streamAnalytics notifySeekStart];
+    SEGLog(@"[[SCORStreamAnalytics streamAnalytics] notifySeekStart]");
 }
 
 - (void)videoPlaybackSeekCompleted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
 
-    if ([properties[@"seek_position"] longValue]) {
-        long seekPosition = [properties[@"seek_position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:seekPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld]", seekPosition);
-    } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
-    }
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//          [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
+   
+    [self seekPosition:properties];
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
 
 
 - (void)videoPlaybackResumed:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedPlaybackProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setLabels:map];
+    SCORStreamingContentMetadata *playbackMetaData = [self instantiateContentMetaData:map];
+//
+//    SCORStreamingContentMetadata *playbackMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//      [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics setMetadata:playbackMetaData];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:&ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
-    }
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
 
 #pragma Content Events
@@ -420,55 +427,53 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
 - (void)videoContentStarted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedContentProperties(properties, integrations);
-    [[self.streamAnalytics playbackSession] setAssetWithLabels:map];
-    SEGLog(@"[[SCORStreamingAnalytics playbackSession] setAssetWithLabels:%@", map);
+    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
 
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld", playPosition);
-    } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay;");
-    }
+//    SCORStreamingContentMetadata *contentMetadata = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//          [builder setCustomLabels:map];
+//    }];
+    [self.streamAnalytics.configuration addLabels:map];
+    [self.streamAnalytics setMetadata:contentMetadata];
+
+    SEGLog(@"[SCORStreamingAnalytics setMetadata:%@", contentMetadata);
+
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay;");
 }
 
 - (void)videoContentPlaying:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
     NSDictionary *map = returnMappedContentProperties(properties, integrations);
+    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
+//    SCORStreamingContentMetadata *contentMetadata = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+//          [builder setCustomLabels:map];
+//    }];
 
+    SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+        [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
+        [builder setRelatedContentMetadata: contentMetadata];
+    }];
     // The presence of ns_st_ad on the StreamingAnalytics's asset means that we just exited an ad break, so
     // we need to call setAsset with the content metadata.  If ns_st_ad is not present, that means the last
     // observed event was related to content, in which case a setAsset call should not be made (because asset
     // did not change).
-    SCORStreamingPlaybackSession *session = [self.streamAnalytics playbackSession];
-    SCORStreamingAsset *asset = [session asset];
-    if ([asset containsLabel:@"ns_st_ad"]) {
-        [[self.streamAnalytics playbackSession] setAssetWithLabels:map];
-        SEGLog(@"[[SCORStreamingAnalytics playbackSession] setAssetWithLabels:%@]", map);
-    }
-
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld]", playPosition);
+    if ([map objectForKey:@"ns_st_ad"]) {
+        [self.streamAnalytics setMetadata:contentMetadata];
     } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
+        [self.streamAnalytics setMetadata:advertisingMetaData];
     }
+    
+    [self movePosition:properties];
+
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
 
 
 - (void)videoContentCompleted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyEndWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEndWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyEnd];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEnd]");
-    }
+    [self.streamAnalytics notifyEnd];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEnd]");
 }
 
 #pragma Ad Events
@@ -500,47 +505,72 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     // StreamingAnalytics's asset. This is because ns_st_ci will have already been set via asset_id in a
     // Content Started calls (if this is a mid or post-roll), or via content_asset_id on Video Playback
     // Started (if this is a pre-roll).
-    NSString *contentId = [[[self.streamAnalytics playbackSession] asset] label:@"ns_st_ci"] ?: @"0";
-    NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
-    [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
-
-    [[self.streamAnalytics playbackSession] setAssetWithLabels:mapWithContentId];
-    SEGLog(@"[[SCORStreamingAnalytics playbackSession] setAssetWithLabels:%@", mapWithContentId);
-
-
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld", playPosition);
-
-    } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
-    }
+    NSString *labels = self.streamAnalytics.configuration.labels;
+//    NSString *contentId = [labels objectForKey:@"ns_st_ci"] ?: @"0";
+//    NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
+//    [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
+//
+//    [[self.streamAnalytics playbackSession] setAssetWithLabels:mapWithContentId];
+//    SEGLog(@"[[SCORStreamingAnalytics playbackSession] setAssetWithLabels:%@", mapWithContentId);
+//
+//
+//    if ([properties[@"position"] longValue]) {
+//        long playPosition = [properties[@"position"] longValue];
+//        [self.streamAnalytics notifyPlayWithPosition:playPosition];
+//        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld", playPosition);
+//
+//    } else {
+//        [self.streamAnalytics notifyPlay];
+//        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
+//    }
 }
 
 - (void)videoAdPlaying:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
-    if ([properties[@"position"] longValue]) {
-        long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyPlay];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
-    }
+    [self movePosition:properties];
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
 
 - (void)videoAdCompleted:(NSDictionary *)properties withOptions:(NSDictionary *)integrations
 {
+    [self.streamAnalytics notifyEnd];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEnd]");
+}
+
+
+#pragma mark - Helper functions
+
+- (void)movePosition:(NSDictionary *)properties {
     if ([properties[@"position"] longValue]) {
         long playPosition = [properties[@"position"] longValue];
-        [self.streamAnalytics notifyEndWithPosition:playPosition];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEndWithPosition:%ld]", playPosition);
-    } else {
-        [self.streamAnalytics notifyEnd];
-        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyEnd]");
+        if (self.streamAnalytics != NULL) {
+            [self.streamAnalytics startFromPosition:playPosition];
+        }
     }
+}
+
+- (void)seekPosition:(NSDictionary *)properties {
+    if ([properties[@"seek_position"] longValue]) {
+        long seekPosition = [properties[@"seek_position"] longValue];
+        if (self.streamAnalytics != NULL) {
+            [self.streamAnalytics startFromPosition:seekPosition];
+        }
+        
+    }
+}
+
+- (SCORStreamingContentMetadata *)instantiateContentMetaData:(NSDictionary *)properties {
+    
+    SCORStreamingContentMetadata *contentMetaData = [SCORStreamingContentMetadata contentMetadataWithBuilderBlock:^(SCORStreamingContentMetadataBuilder *builder) {
+        [builder setCustomLabels:properties];
+        
+        if (properties[@"ns_st_ge"]) {
+            [builder setGenreName:properties[@"genre"]];
+        }
+    }];
+  
+    return contentMetaData;
 }
 
 @end

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -505,24 +505,24 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *i
     // StreamingAnalytics's asset. This is because ns_st_ci will have already been set via asset_id in a
     // Content Started calls (if this is a mid or post-roll), or via content_asset_id on Video Playback
     // Started (if this is a pre-roll).
-    NSString *labels = self.streamAnalytics.configuration.labels;
-//    NSString *contentId = [labels objectForKey:@"ns_st_ci"] ?: @"0";
-//    NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
-//    [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
-//
-//    [[self.streamAnalytics playbackSession] setAssetWithLabels:mapWithContentId];
-//    SEGLog(@"[[SCORStreamingAnalytics playbackSession] setAssetWithLabels:%@", mapWithContentId);
-//
-//
-//    if ([properties[@"position"] longValue]) {
-//        long playPosition = [properties[@"position"] longValue];
-//        [self.streamAnalytics notifyPlayWithPosition:playPosition];
-//        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlayWithPosition:%ld", playPosition);
-//
-//    } else {
-//        [self.streamAnalytics notifyPlay];
-//        SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
-//    }
+    NSDictionary *labels = self.streamAnalytics.configuration.labels;
+    NSString *contentId = [labels objectForKey:@"ns_st_ci"] ?: @"0";
+    
+    NSMutableDictionary *mapWithContentId = [NSMutableDictionary dictionaryWithDictionary:map];
+    [mapWithContentId setValue:contentId forKey:@"ns_st_ci"];
+    
+    SCORStreamingContentMetadata *contentMetadata = [self instantiateContentMetaData:map];
+                                                     
+    SCORStreamingAdvertisementMetadata * advertisingMetaData = [SCORStreamingAdvertisementMetadata advertisementMetadataWithBuilderBlock:^(SCORStreamingAdvertisementMetadataBuilder *builder) {
+        [builder setMediaType: SCORStreamingAdvertisementTypeOnDemandPreRoll];
+        [builder setRelatedContentMetadata: contentMetadata];
+    }];
+    
+    [self.streamAnalytics setMetadata:advertisingMetaData];
+
+    [self movePosition: properties];
+    [self.streamAnalytics notifyPlay];
+    SEGLog(@"[[SCORStreamingAnalytics streamAnalytics] notifyPlay]");
 }
 
 - (void)videoAdPlaying:(NSDictionary *)properties withOptions:(NSDictionary *)integrations


### PR DESCRIPTION
Updates to Comscore to use 6.0:
- [x] Remove calls to `publisherSecret` method on the `builder`
- [x] Move application name on `builder` to general config settings 
- [x] Move calls to specify alternative usage properties auto-update settings on `thePublisherConfiguration.Builder()` to the general configuration settings.
- [x] Remove `createPlaybackSessionWithLabels` to just `createPlaybackSession`. Will add labels to the configuration and send metadata separately using `addLabels` and `setMetadata` respectively. 
- [x] Map playback, content, and ad metadata the same as in previous Segment-Comscore versions
- [x] Remove notify with position from the following events per documentation and parity with Android SDK: `videoPlaybackPaused`, `videoPlaybackInterrupted`, `videoContentCompleted`
- [x] Use helper function to `notifyPlayWithPostion`


To Discuss During in Person Review: 
1. Line 479 `NSDictionary *labels = self.streamAnalytics.configuration.labels;` throws an error when I run make lint which runs the pod lib lint with error `error: property 'labels' not found on object of type 'SCORStreamingConfiguration *'`. Despite compiling properly and assigning `labels` correctly when I . trigger a Video Ad Started Event in the `SEGAppDelegate.m`. 
2. `videoContentPlaying` may need to update implementation to check the `streamingAnalytics.configuration.labels` for `@"ns_st_ad"` to see if we just exited an ad break pending the above working as expected. 