### PR TITLE
Support for namechange from Analytics->Segment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "11.0"
+      xcode: "12.0"
     steps:
       - checkout
       - run: xcrun simctl list
@@ -11,7 +11,7 @@ jobs:
           name: Install build dependencies
           command: |
             sudo gem install xcpretty
-            sudo gem install cocoapods -v 1.6.1
+            sudo gem install cocoapods -v 1.9.3
       - run:
           name: Fetch Cocoapods specs
           command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '11.0'
 
 target 'Segment-ComScore_Example' do
   pod 'Segment-ComScore', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-ComScore (4.2.0):
+  - Segment-ComScore (4.2.1):
     - Analytics
     - ComScore (~> 6.0)
   - Specta (1.0.7)
@@ -37,9 +37,9 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
-  Segment-ComScore: 2ad7cef430b8e43f558542f1b6b733e1e7730d11
+  Segment-ComScore: c6f035152757253bb116b27b028aeb0e84d1c770
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
-PODFILE CHECKSUM: 6caa57386b7498cd62793f0f7cb29b5b2dbe2852
+PODFILE CHECKSUM: 7186380f43d2f298e5743efcc638c9b7edcbbcab
 
 COCOAPODS: 1.9.3

--- a/Example/Segment-ComScore.xcodeproj/project.pbxproj
+++ b/Example/Segment-ComScore.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-resources.sh\"\n";
+			shellScript = "export ARCHS=\"$(ARCHS_STANDARD)\"\n\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F951B112C3EA87F573856FD5 /* [CP] Embed Pods Frameworks */ = {
@@ -400,7 +400,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Tests/Pods-Segment-ComScore_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Segment.framework",
+				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Analytics.framework",
 				"${PODS_ROOT}/ComScore/ComScore/dynamic/iOS/ComScore.framework",
 				"${BUILT_PRODUCTS_DIR}/Segment-ComScore-framework/Segment_ComScore.framework",
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
@@ -410,7 +410,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ComScore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment_ComScore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",

--- a/Example/Segment-ComScore.xcodeproj/project.pbxproj
+++ b/Example/Segment-ComScore.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export ARCHS=\"$(ARCHS_STANDARD)\"\n\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-frameworks.sh\"\n";
 		};
 		54E6C44137E073B1193A3FE6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -390,7 +390,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export ARCHS=\"$(ARCHS_STANDARD)\"\n\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F951B112C3EA87F573856FD5 /* [CP] Embed Pods Frameworks */ = {
@@ -511,7 +511,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv7 armv7s";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Debug;
 		};
@@ -545,7 +545,7 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "armv7 armv7s";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Release;
 		};

--- a/Example/Segment-ComScore.xcodeproj/project.pbxproj
+++ b/Example/Segment-ComScore.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Tests/Pods-Segment-ComScore_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Analytics.framework",
+				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Segment.framework",
 				"${PODS_ROOT}/ComScore/ComScore/dynamic/iOS/ComScore.framework",
 				"${BUILT_PRODUCTS_DIR}/Segment-ComScore-framework/Segment_ComScore.framework",
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
@@ -410,7 +410,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ComScore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment_ComScore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
@@ -507,7 +507,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -541,7 +541,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 8"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
 PROJECT := Segment-ComScore
-XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
+XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=YES
 
 install: Example/Podfile $(PROJECT).podspec
 	pod repo update

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 [![License](https://img.shields.io/cocoapods/l/Segment-ComScore.svg?style=flat)](http://cocoapods.org/pods/Segment-ComScore)
 [![Platform](https://img.shields.io/cocoapods/p/Segment-ComScore.svg?style=flat)](http://cocoapods.org/pods/Segment-ComScore)
 
+## NOTE
+
+This integration needs special care when building with anything lower than Xcode 12 due to the ComScore SDK.
+
+When using Xcode 11 or lower, you will need to add the following as the first line of your `[CP] Embed Pods Frameworks` phase:
+
+```
+export ARCHS="$(ARCHS_STANDARD)"
+```
+
 ## Example
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.h
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.h
@@ -7,8 +7,14 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGIntegration.h>
 #import <ComScore/ComScore.h>
+
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
+#import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
+
 
 
 @protocol SEGStreamingAnalyticsFactory <NSObject>

--- a/Segment-ComScore/Classes/SEGComScoreIntegration.m
+++ b/Segment-ComScore/Classes/SEGComScoreIntegration.m
@@ -7,8 +7,13 @@
 //
 
 #import "SEGComScoreIntegration.h"
-#import <Analytics/SEGAnalyticsUtils.h>
 #import <ComScore/SCORStreamingAnalytics.h>
+
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
+#import <Analytics/SEGAnalyticsUtils.h>
+#else
+#import <Segment/SEGAnalyticsUtils.h>
+#endif
 
 @implementation SEGRealStreamingAnalyticsFactory
 

--- a/Segment-ComScore/Classes/SEGComScoreIntegrationFactory.h
+++ b/Segment-ComScore/Classes/SEGComScoreIntegrationFactory.h
@@ -7,7 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 
 @interface SEGComScoreIntegrationFactory : NSObject <SEGIntegrationFactory>


### PR DESCRIPTION
- Allows for this integration to support the upcoming module name change from `Analytics` to `Segment`.

NOTE: Comscore is already building with Xcode 12, so a change is necessary in the copy script such that ARCHS is present.  The line is effectively: `export ARCHS="$(ARCHS_STANDARD)"`.  It's important to mention because pod changes cause this change to get lost.