### PR TITLE
Update example to verify compatibility

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Analytics (4.0.5)
-  - ComScore (6.6.0):
-    - ComScore/Dynamic (= 6.6.0)
-  - ComScore/Dynamic (6.6.0)
+  - Analytics (4.1.6)
+  - ComScore (6.9.0):
+    - ComScore/Dynamic (= 6.9.0)
+  - ComScore/Dynamic (6.9.0)
   - Expecta (1.0.6)
-  - OCHamcrest (7.1.2)
-  - OCMockito (5.1.3):
-    - OCHamcrest (~> 7.0)
-  - Segment-ComScore (4.2.1):
+  - OCHamcrest (8.0.0)
+  - OCMockito (6.0.0):
+    - OCHamcrest (~> 8.0)
+  - Segment-ComScore (4.4.1):
     - Analytics
     - ComScore (~> 6.0)
   - Specta (1.0.7)
@@ -32,14 +32,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: 4bcf052c91e1f3339219e83d6a036fb2bd7c218d
-  ComScore: 13377ad241b0ec2f006eac64ec5cdc431f754430
+  Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
+  ComScore: 4fcff6ce4e4bc2df3592d15dc69be8fcc8aaadad
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
-  OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
-  Segment-ComScore: c6f035152757253bb116b27b028aeb0e84d1c770
+  OCHamcrest: a613690381f1dac7637c18962c10dbe8feca4bb5
+  OCMockito: 780f04370226f81a9d972c97d1203864ef609f5b
+  Segment-ComScore: c422ecd8f622d916463afc543c57f1393ebea325
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 7186380f43d2f298e5743efcc638c9b7edcbbcab
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.11.2

--- a/Example/Segment-ComScore.xcodeproj/project.pbxproj
+++ b/Example/Segment-ComScore.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Example/Pods-Segment-ComScore_Example-frameworks.sh",
-				"${PODS_ROOT}/ComScore/ComScore/dynamic/iOS/ComScore.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ComScore/Dynamic/ComScore.framework/ComScore",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -400,23 +400,23 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-ComScore_Tests/Pods-Segment-ComScore_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Analytics.framework",
-				"${PODS_ROOT}/ComScore/ComScore/dynamic/iOS/ComScore.framework",
+				"${BUILT_PRODUCTS_DIR}/Analytics-framework/Segment.framework",
 				"${BUILT_PRODUCTS_DIR}/Segment-ComScore-framework/Segment_ComScore.framework",
 				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
 				"${BUILT_PRODUCTS_DIR}/OCHamcrest/OCHamcrest.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMockito/OCMockito.framework",
 				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ComScore/Dynamic/ComScore.framework/ComScore",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ComScore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment_ComScore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCHamcrest.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMockito.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ComScore.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Segment-ComScore/SEGAppDelegate.m
+++ b/Example/Segment-ComScore/SEGAppDelegate.m
@@ -18,7 +18,6 @@
     [SEGAnalytics debug:YES];
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"ACIG3kwqCUsWZBfYxZDu0anuGwP3XtWW"];
     configuration.trackApplicationLifecycleEvents = YES;
-    configuration.trackAttributionData = YES;
     configuration.flushAt = 1;
     [configuration use:[SEGComScoreIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:configuration];


### PR DESCRIPTION
- Verified Comscore 6.9 comes down on a pod update/install.
- Fixed issue w/ deprecated property in Example in Analytics-iOS.
- Verified compatibility with 6.9
- No new release is necessary.